### PR TITLE
Fix broken link to quickstart document

### DIFF
--- a/README
+++ b/README
@@ -3,9 +3,10 @@ eXist Native XML Database
 =========================
 
 For instructions on how to install and start eXist, please
-refer to http://exist-db.org/quickstart.html. Alternatively 
-you may directly start the database with the included Jetty 
-webserver and read the documentation which will be available at
+refer to http://exist-db.org/exist/apps/doc/quickstart.xml. 
+Alternatively you may directly start the database with the 
+included Jetty webserver and read the documentation which will be 
+available at
 
 http://localhost:8080/exist/
 


### PR DESCRIPTION
### Description:

The README file contained a link to the old location of the quickstart document.

Whether README is still needed (given the presence of README.md and BUILD.md) is not addressed here. This PR just updates an old URL.

### Reference:

n/a

### Type of tests:

n/a