### PR TITLE
[fix] Preceding/following axes miss nodes when predicates add context tracking

### DIFF
--- a/exist-core/src/main/java/org/exist/dom/persistent/NewArrayNodeSet.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/NewArrayNodeSet.java
@@ -792,6 +792,7 @@ public class NewArrayNodeSet extends AbstractArrayNodeSet implements ExtNodeSet,
                 if(!reference.getNodeId().isDescendantOf(nodes[j].getNodeId())) {
                     if(position < 0 || ++n == position) {
                         if (contextId != Expression.IGNORE_CONTEXT
+                                && contextId != Expression.NO_CONTEXT_ID
                                 && nodes[j].getContext() != null
                                 && reference.getContext() != null
                                 && nodes[j].getContext().getContextId() == reference.getContext().getContextId()) {
@@ -846,6 +847,7 @@ public class NewArrayNodeSet extends AbstractArrayNodeSet implements ExtNodeSet,
                 if(!reference.getNodeId().isDescendantOf(nodes[j].getNodeId())) {
                     if(position < 0 || ++n == position) {
                         if (contextId != Expression.IGNORE_CONTEXT
+                                && contextId != Expression.NO_CONTEXT_ID
                                 && nodes[j].getContext() != null
                                 && reference.getContext() != null
                                 && nodes[j].getContext().getContextId() == reference.getContext().getContextId()) {

--- a/exist-core/src/test/xquery/axes-persistent-nodes.xqm
+++ b/exist-core/src/test/xquery/axes-persistent-nodes.xqm
@@ -104,6 +104,25 @@ function axpn:preceding-with-predicate-db-map() {
 
 declare
     %test:assertEquals("w1:pb1", "w2:pb1", "w3:pb1", "w4:pb2", "w5:pb2")
+function axpn:preceding-with-context-predicate-db-flwor() {
+    for $w in doc("/db/test/test.xml")//w[exists(.)]
+    let $preceding-page := $w/preceding::pb[1]
+    return
+        if ($preceding-page) then
+            $w/@id || ":" || $preceding-page/@id
+        else
+            $w/@id || ":PRECEDING_PB_NOT_FOUND"
+};
+
+declare
+    %test:assertEquals("w1:pb1", "w2:pb1", "w3:pb1", "w4:pb2", "w5:pb2")
+function axpn:preceding-with-context-predicate-db-map() {
+    doc("/db/test/test.xml")//w[exists(.)]
+        ! (./@id || ":" || (./preceding::pb[1]/@id, "PRECEDING_PB_NOT_FOUND")[1])
+};
+
+declare
+    %test:assertEquals("w1:pb1", "w2:pb1", "w3:pb1", "w4:pb2", "w5:pb2")
 function axpn:preceding-without-predicate-flwor() {
     for $w in doc("/db/test/test.xml")//w
     let $preceding-page := $w/preceding::pb[1]
@@ -158,6 +177,25 @@ declare
     %test:assertEquals("w1:pb2", "w2:pb2", "w3:pb2", "w4:pb3", "w5:pb3")
 function axpn:following-with-predicate-db-map() {
     doc("/db/test/test.xml")//w[true()]
+        ! (./@id || ":" || (./following::pb[1]/@id, "FOLLOWING_PB_NOT_FOUND")[1])
+};
+
+declare
+    %test:assertEquals("w1:pb2", "w2:pb2", "w3:pb2", "w4:pb3", "w5:pb3")
+function axpn:following-with-context-predicate-db-flwor() {
+    for $w in doc("/db/test/test.xml")//w[exists(.)]
+    let $following-page := $w/following::pb[1]
+    return
+        if ($following-page) then
+            $w/@id || ":" || $following-page/@id
+        else
+            $w/@id || ":FOLLOWING_PB_NOT_FOUND"
+};
+
+declare
+    %test:assertEquals("w1:pb2", "w2:pb2", "w3:pb2", "w4:pb3", "w5:pb3")
+function axpn:following-with-context-predicate-db-map() {
+    doc("/db/test/test.xml")//w[exists(.)]
         ! (./@id || ":" || (./following::pb[1]/@id, "FOLLOWING_PB_NOT_FOUND")[1])
 };
 


### PR DESCRIPTION
Closes eXist-db/exist#4109.

### Problem

The `preceding::` and `following::` axes skip nodes when the input node set was produced by an expression with a context-dependent predicate. For example:

```xquery
(: Expected: w1:pb1, w2:pb1, w3:pb1, w4:pb2, w5:pb2 :)
(: Actual:   w1:pb1, w2:PRECEDING_PB_NOT_FOUND, w3:PRECEDING_PB_NOT_FOUND, w4:pb2, w5:PRECEDING_PB_NOT_FOUND :)
for $w in doc("/db/test/test.xml")//w[exists(.)]
let $preceding-page := $w/preceding::pb[1]
return $w/@id || ":" || ($preceding-page/@id, "PRECEDING_PB_NOT_FOUND")[1]
```

The predicate `[exists(.)]` is a no-op logically, but it triggers context tracking: the `self::` axis evaluation inside the predicate attaches a context entry to each `NodeProxy` in the result set. When these nodes are later used as input to `preceding::` or `following::`, the context entries leak through `copyContext()` into the axis result nodes. The context ID deduplication check in `NewArrayNodeSet.selectPreceding()` / `selectFollowing()` then sees a matching context ID and incorrectly skips valid result nodes, treating them as duplicates.

### Approach

The fix adds a `NO_CONTEXT_ID` guard to the existing `IGNORE_CONTEXT` check in both `selectFollowing()` and `selectPreceding()` of `NewArrayNodeSet`. When `contextId` is `NO_CONTEXT_ID` (meaning the axis step is not inside a predicate context tracking scope), the context-based deduplication check is skipped — the same behavior as `IGNORE_CONTEXT`.

The change is two lines (one per method), following the same pattern already used elsewhere in the codebase where `IGNORE_CONTEXT` and `NO_CONTEXT_ID` are treated as equivalent for dedup purposes.

### XQTS results

| Test set | Before (develop) | After (this PR) | Notes |
|---|---|---|---|
| `prod-AxisStep` | 46 failures | 46 failures | No change — all pre-existing |
| `prod-AxisStep.following` | 2 failures | 2 failures | No change — all pre-existing |
| `prod-AxisStep.preceding` | 2 failures | 2 failures | No change — all pre-existing |

No regressions introduced.

> **Note:** The XQTS axis tests do not cover the specific scenario of context tracking leaking through predicates on the input expression, which is why there is no XQTS improvement. The issue manifests specifically with persistent (database-stored) nodes and context-dependent predicates on the input node set — a scenario tested by the new XQSuite tests below.

### Test plan

- [x] 4 new XQSuite tests in `axes-persistent-nodes.xqm` covering both `preceding::` and `following::` axes with context predicates, in both FLWOR and simple map forms
- [x] Full eXist test suite: 6,476 tests, **0 failures**, 129 skipped
- [x] XQTS `prod-AxisStep`, `prod-AxisStep.following`, `prod-AxisStep.preceding`: no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)