### PR TITLE
[fix] Allow empty enclosed expressions in computed document, comment, and namespace constructors

### DIFF
--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
@@ -1765,7 +1765,7 @@ compTextConstructor throws XPathException
 
 compDocumentConstructor throws XPathException
 :
-	"document" LCURLY! e:expr RCURLY!
+	"document" LCURLY! (e:expr)? RCURLY!
 	{ #compDocumentConstructor = #(#[COMP_DOC_CONSTRUCTOR, "document"], #e); }
 	;
 
@@ -1782,7 +1782,7 @@ compXmlPI throws XPathException
 
 compXmlComment throws XPathException
 :
-	"comment" LCURLY! e:expr RCURLY!
+	"comment" LCURLY! (e:expr)? RCURLY!
 	{ #compXmlComment = #(#[COMP_COMMENT_CONSTRUCTOR, "comment"], #e); }
 	;
 

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -3718,7 +3718,7 @@ throws PermissionDeniedException, EXistException, XPathException
             comment.setASTNode(t);
             step= comment;
         }
-        contentExpr=expr [elementContent]
+        (contentExpr=expr [elementContent])?
     )
     |
     #(
@@ -3730,7 +3730,7 @@ throws PermissionDeniedException, EXistException, XPathException
             doc.setASTNode(d);
             step= doc;
         }
-        contentExpr=expr [elementContent]
+        (contentExpr=expr [elementContent])?
     )
     |
     #(

--- a/exist-core/src/main/java/org/exist/xquery/DynamicCommentConstructor.java
+++ b/exist-core/src/main/java/org/exist/xquery/DynamicCommentConstructor.java
@@ -71,11 +71,12 @@ public class DynamicCommentConstructor extends NodeConstructor {
         Sequence result;
         try {
             final Sequence contentSeq = content.eval(contextSequence, contextItem);
-            if (contentSeq.isEmpty())
-                {result = Sequence.EMPTY_SEQUENCE;}
-            else {
-                final MemTreeBuilder builder = context.getDocumentBuilder();
-                context.proceed(this, builder);
+            final MemTreeBuilder builder = context.getDocumentBuilder();
+            context.proceed(this, builder);
+            if (contentSeq.isEmpty()) {
+                final int nodeNr = builder.comment("");
+                result = builder.getDocument().getNode(nodeNr);
+            } else {
                 final StringBuilder buf = new StringBuilder();
                 for(final SequenceIterator i = Atomize.atomize(contentSeq).iterate(); i.hasNext(); ) {
                     context.proceed(this, builder);
@@ -86,7 +87,7 @@ public class DynamicCommentConstructor extends NodeConstructor {
                 }
                 if (buf.indexOf("--") != Constants.STRING_NOT_FOUND ||
                         buf.toString().endsWith("-")) {
-                    throw new XPathException(this, ErrorCodes.XQDY0072, 
+                    throw new XPathException(this, ErrorCodes.XQDY0072,
                         "'" + buf + "' is not a valid comment");
                 }
                 final int nodeNr = builder.comment(buf.toString());

--- a/exist-core/src/main/java/org/exist/xquery/NamespaceConstructor.java
+++ b/exist-core/src/main/java/org/exist/xquery/NamespaceConstructor.java
@@ -47,7 +47,7 @@ public class NamespaceConstructor extends NodeConstructor {
 
     public void setContentExpr(final PathExpr path) {
         path.setUseStaticContext(true);
-        final Expression expr = new DynamicCardinalityCheck(context, Cardinality.EXACTLY_ONE, path,
+        final Expression expr = new DynamicCardinalityCheck(context, Cardinality.ZERO_OR_ONE, path,
                 new Error(Error.FUNC_PARAM_CARDINALITY));
         this.content = expr;
     }

--- a/exist-core/src/test/xquery/xquery3/empty-computed-constructor.xqm
+++ b/exist-core/src/test/xquery/xquery3/empty-computed-constructor.xqm
@@ -1,0 +1,82 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+(:~
+ : Tests for empty computed constructors.
+ :
+ : @see https://github.com/eXist-db/exist/issues/4593
+ : @see https://github.com/eXist-db/exist/issues/4594
+ : @see https://github.com/eXist-db/exist/issues/4595
+ :)
+module namespace ecc = "http://exist-db.org/xquery/test/empty-computed-constructors";
+
+declare namespace test = "http://exist-db.org/xquery/xqsuite";
+
+(:~ document {} should produce a document node (issue #4593) :)
+declare
+    %test:assertTrue
+function ecc:empty-document-constructor() {
+    document {} instance of document-node()
+};
+
+(:~ document { () } should also produce a document node :)
+declare
+    %test:assertTrue
+function ecc:empty-document-constructor-with-empty-sequence() {
+    document { () } instance of document-node()
+};
+
+(:~ comment {} should produce a comment node (issue #4594) :)
+declare
+    %test:assertTrue
+function ecc:empty-comment-constructor() {
+    comment {} instance of comment()
+};
+
+(:~ comment { () } should also produce a comment node :)
+declare
+    %test:assertTrue
+function ecc:empty-comment-constructor-with-empty-sequence() {
+    comment { () } instance of comment()
+};
+
+(:~ comment {} should have zero-length string value :)
+declare
+    %test:assertEquals("")
+function ecc:empty-comment-string-value() {
+    string(comment {})
+};
+
+(:~ namespace foo {} should raise XQDY0101 (issue #4595) :)
+declare
+    %test:assertError("XQDY0101")
+function ecc:empty-namespace-constructor() {
+    namespace foo {}
+};
+
+(:~ namespace foo { () } should also raise XQDY0101 :)
+declare
+    %test:assertError("XQDY0101")
+function ecc:empty-namespace-constructor-with-empty-sequence() {
+    namespace foo { () }
+};


### PR DESCRIPTION
Closes eXist-db/exist#4593. Also closes eXist-db/exist#4594, eXist-db/exist#4595.

### Problem

XQuery 3.1 [§3.7.3.1](https://www.w3.org/TR/xquery-31/#id-computed-constructors) allows empty enclosed expressions in computed constructors. Prior to XQuery 3.1, the enclosed expression was required; XQuery 3.1 made it optional for `document {}`, `comment {}`, and `namespace foo {}` (among others). eXist-db's parser and evaluator did not support this:

- **`document {}`** (issue #4593): The grammar required a non-empty `expr` inside `LCURLY`/`RCURLY`, so the parser rejected `document {}` with `err:XPST0003 "unexpected token: }"`.

- **`comment {}`** (issue #4594): Same grammar problem — rejected with `err:XPST0003`. Additionally, `comment { () }` was accepted by the parser but evaluated to `EMPTY_SEQUENCE` instead of producing an empty comment node `<!---->`.

- **`namespace foo {}`** (issue #4595): The parser accepted the empty expression, but `NamespaceConstructor` applied a `EXACTLY_ONE` cardinality check, raising `XPTY0004` instead of the correct `XQDY0101` (zero-length namespace URI).

### Approach

The fix addresses each layer — grammar, tree parser, and evaluator:

1. **Grammar** (`XQuery.g`): Make the enclosed expression optional in `compDocumentConstructor` and `compXmlComment` rules by changing `e:expr` to `(e:expr)?`. This matches how `compNamespaceConstructor` and `compConstructorValue` already handle the enclosed expression.

2. **Tree parser** (`XQueryTree.g`): Make the content expression optional in the tree walker for `COMP_COMMENT_CONSTRUCTOR` and `COMP_DOC_CONSTRUCTOR` AST nodes, by changing `contentExpr=expr [elementContent]` to `(contentExpr=expr [elementContent])?`.

3. **`DynamicCommentConstructor.java`**: When the content sequence is empty, create a comment node with a zero-length string value per [XQuery 3.1 §3.7.3.5](https://www.w3.org/TR/xquery-31/#id-computedComments) ("If the content expression is empty, a comment node is created whose string value is the zero-length string") instead of returning `EMPTY_SEQUENCE`.

4. **`NamespaceConstructor.java`**: Change the cardinality check from `EXACTLY_ONE` to `ZERO_OR_ONE` for the content expression. This allows an empty content expression to reach the namespace URI validation, where it correctly raises `XQDY0101` (zero-length namespace URI for a non-default namespace) instead of the misleading `XPTY0004` cardinality error.

### XQTS results

| Test set | Before (develop) | After (this PR) | Notes |
|---|---|---|---|
| `prod-CompCommentConstructor` | 4 failures | 4 failures | `K2-ComputeConComment-3` fixed (see below); `K2-ComputeConComment-4` is an expected XQ10→XQ31 behavioral change (see below) |
| `prod-CompDocConstructor` | 18 failures | 18 failures | No change — all 18 are pre-existing |
| `prod-CompNamespaceConstructor` | 6 failures, 1 error | 6 failures, 1 error | No change — all pre-existing |

**`K2-ComputeConComment-3`** (fixed): This test evaluates `comment {()}` and expects an empty comment node `<!---->`. On `develop`, eXist returned an empty sequence instead. Now passes.

**`K2-ComputeConComment-4`** (expected behavioral change): This test has a `dependency type="spec" value="XQ10 XQ30"` — it asserts that `comment{}` should raise `XPST0003` because the enclosed expression was **not** optional in those earlier spec versions. Its companion test `K2-ComputeConComment-4a` (with `dependency type="spec" value="XQ31+"`) asserts that the same query should **succeed** and produce an empty comment node. Since eXist implements XQuery 3.1, the new behavior is correct per spec. This is not a regression — it reflects the XQ10→XQ31 semantic change. The XQTS runner counts it as a "failure" because it enables all spec versions by default, but the XQ31+ companion test would pass.

> **Note:** The 18 pre-existing `prod-CompDocConstructor` failures and the other pre-existing failures are unrelated to this PR and exist on `develop`.

### Test plan

- [x] 7 new XQSuite tests in `empty-computed-constructor.xqm` covering all three issues
- [x] Full eXist test suite: 6,479 tests, **0 failures**, 129 skipped
- [x] XQTS `prod-CompCommentConstructor`, `prod-CompDocConstructor`, `prod-CompNamespaceConstructor`: no regressions (1 test fixed, 1 expected XQ31 behavioral change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)