### PR TITLE
[fix] Fix string literals in attribute value templates

### DIFF
--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
@@ -2048,7 +2048,7 @@ enclosedExpr throws XPathException
 attributeEnclosedExpr throws XPathException
 :
     ( LCURLY RCURLY ) => LCURLY! RCURLY!
-    { lexer.inAttributeContent= true; }
+    { lexer.inAttributeContent= true; lexer.parseStringLiterals = false; }
     |
 	LCURLY^
 	{
@@ -2699,6 +2699,9 @@ options {
 	{ !inStringConstructor }?
 	LCURLY
 	{
+		if (inAttributeContent) {
+			parseStringLiterals = true;
+		}
 		inElementContent= false;
 		inAttributeContent= false;
 		$setType(LCURLY);

--- a/exist-core/src/test/java/org/exist/xquery/StringLiteralInAttributeConstructorTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/StringLiteralInAttributeConstructorTest.java
@@ -1,0 +1,85 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery;
+
+import org.exist.EXistException;
+import org.exist.security.PermissionDeniedException;
+import org.exist.test.XQueryCompilationTest;
+import org.junit.Test;
+
+import static org.exist.test.DiffMatcher.elemSource;
+import static org.exist.test.XQueryAssertions.assertXQResultSimilar;
+
+/**
+ * Ensure string literals can be used inside attribute value templates.
+ * See issue: <a href="https://github.com/eXist-db/exist/issues/291">#291</a>.
+ */
+public class StringLiteralInAttributeConstructorTest extends XQueryCompilationTest {
+
+    @Test
+    public void singleQuotedStringInDoubleQuotedAttribute() throws EXistException, PermissionDeniedException {
+        final String query = "<root a=\"{'a'}\"/>";
+        assertXQResultSimilar(elemSource("<root a='a'/>"), executeQuery(query));
+    }
+
+    @Test
+    public void doubleQuotedStringInSingleQuotedAttribute() throws EXistException, PermissionDeniedException {
+        final String query = "<root a='{\"a\"}'/>";
+        assertXQResultSimilar(elemSource("<root a='a'/>"), executeQuery(query));
+    }
+
+    @Test
+    public void numericLiteralInAttribute() throws EXistException, PermissionDeniedException {
+        final String query = "<root a=\"{1}\"/>";
+        assertXQResultSimilar(elemSource("<root a='1'/>"), executeQuery(query));
+    }
+
+    @Test
+    public void concatStringWithEmptySequence() throws EXistException, PermissionDeniedException {
+        final String query = "<root a=\"{() || 'a'}\"/>";
+        assertXQResultSimilar(elemSource("<root a='a'/>"), executeQuery(query));
+    }
+
+    @Test
+    public void variableSubstitution() throws EXistException, PermissionDeniedException {
+        final String query = "let $a := 'a' return <root a=\"{$a}\"/>";
+        assertXQResultSimilar(elemSource("<root a='a'/>"), executeQuery(query));
+    }
+
+    @Test
+    public void stringConstructor() throws EXistException, PermissionDeniedException {
+        final String query = "<root a=\"{``[a]``}\"/>";
+        assertXQResultSimilar(elemSource("<root a='a'/>"), executeQuery(query));
+    }
+
+    @Test
+    public void multipleAttributesWithStringLiterals() throws EXistException, PermissionDeniedException {
+        final String query = "<root a=\"{'a'}\" b=\"{'b'}\"/>";
+        assertXQResultSimilar(elemSource("<root a='a' b='b'/>"), executeQuery(query));
+    }
+
+    @Test
+    public void stringConcatInAttribute() throws EXistException, PermissionDeniedException {
+        final String query = "<root a=\"{'hello' || ' ' || 'world'}\"/>";
+        assertXQResultSimilar(elemSource("<root a='hello world'/>"), executeQuery(query));
+    }
+}


### PR DESCRIPTION
Closes eXist-db/exist#291.

### Problem

String literals inside enclosed expressions within attribute value templates cause a parse error:

```xquery
<root a="{'a'}"/>
(: err:XPST0003 — unexpected token :)
```

This is a [longstanding issue](https://github.com/eXist-db/exist/issues/291) (opened 2014) affecting any use of quoted strings in attribute enclosed expressions. Numeric literals and variable references work fine (`<root a="{1}"/>`, `<root a="{$x}"/>`), but string literals fail.

### Root cause

eXist-db uses ANTLR 2, which evaluates syntactic predicates by performing lookahead — consuming tokens and caching them. The `attributeEnclosedExpr` rule has a syntactic predicate `( LCURLY RCURLY ) =>` to detect empty enclosed expressions (`{}`). During this lookahead:

1. The lexer produces `LCURLY`, running its action: `inAttributeContent = false`, `inElementContent = false`
2. The lexer tries to produce the next token. With `parseStringLiterals = false`, a quote character (`'`) matches the `APOS` alternative instead of starting a `STRING_LITERAL`
3. `APOS ≠ RCURLY`, so the syntactic predicate fails and ANTLR rewinds the token stream position
4. **But the incorrectly-tokenized `APOS` is already cached** — when the parser takes the non-empty expression alternative and the parser action sets `parseStringLiterals = true`, it's too late. The lexer has already committed to `APOS`.

### Approach

The fix ensures `parseStringLiterals` is set at the **lexer level** during the `LCURLY` token action, before any syntactic predicate can cache incorrectly-tokenized tokens:

1. **`XQuery.g` lexer LCURLY action** (line ~2700): When `inAttributeContent` is true, set `parseStringLiterals = true` immediately. This ensures that during syntactic predicate evaluation, any quote character encountered after `{` is correctly tokenized as a string literal delimiter.

2. **`XQuery.g` parser empty expression handler** (line ~2050): Reset `parseStringLiterals = false` alongside the existing `inAttributeContent = true` restoration. Without this, `parseStringLiterals` would remain `true` after an empty `{}` in an attribute, causing the closing attribute delimiter to be misparsed.

The second fix was discovered during testing: the existing test `<elem attribute="content{}content" />` (from `empty-direct-constructor.xqm`) would fail without it.

### XQTS results

| Test set | Before (develop) | After (this PR) | Notes |
|---|---|---|---|
| `prod-DirElemConstructor` | 11 failures, 1 error | 11 failures, 1 error | No change — all pre-existing |
| `prod-CompAttrConstructor` | 44 failures | 44 failures | No change — all pre-existing |

No regressions introduced.

### Test plan

- [x] 8 new Java tests in `StringLiteralInAttributeConstructorTest` covering: single-quoted strings in double-quoted attributes, double-quoted strings in single-quoted attributes, numeric literals, concat with empty sequence, variable substitution, string constructors, multiple attributes, and string concatenation
- [x] Pre-existing `empty-direct-constructor.xqm` tests continue to pass (including `content{}content` in attributes)
- [x] Full eXist test suite: 6,480 tests, **0 failures**, 129 skipped
- [x] XQTS `prod-DirElemConstructor`, `prod-CompAttrConstructor`: no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)