### PR TITLE
Fix for eXist-db/exist #6083

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/LocationStep.java
+++ b/exist-core/src/main/java/org/exist/xquery/LocationStep.java
@@ -95,15 +95,9 @@ public class LocationStep extends Step {
     public int getDependencies() {
         int deps = Dependency.CONTEXT_SET;
 
-        // The context item expression "." is parsed as self::node() but genuinely
-        // depends on the context item, even inside predicates. Without this,
-        // Predicate.recomputeExecutionMode() may pre-evaluate expressions like
-        // not(.) against the full context sequence instead of item-by-item,
-        // causing FORG0006 errors on atomic sequences (GitHub #2308).
-        if (this.axis == Constants.SELF_AXIS && this.test.getType() == Type.NODE) {
-            // This is "." (context item expression) — always depends on context item
-            deps = deps | Dependency.CONTEXT_ITEM;
-        } else if (!this.inPredicate &&
+        // self axis has an obvious dependency on the context item
+        // likewise we depend on the context item if this is a single path step (outside a predicate)
+        if (!this.inPredicate &&
                 (this.axis == Constants.SELF_AXIS ||
                         (parent != null && parent.getSubExpressionCount() > 0 && parent.getSubExpression(0) == this))) {
             deps = deps | Dependency.CONTEXT_ITEM;

--- a/exist-core/src/main/java/org/exist/xquery/LocationStep.java
+++ b/exist-core/src/main/java/org/exist/xquery/LocationStep.java
@@ -95,9 +95,15 @@ public class LocationStep extends Step {
     public int getDependencies() {
         int deps = Dependency.CONTEXT_SET;
 
-        // self axis has an obvious dependency on the context item
-        // likewise we depend on the context item if this is a single path step (outside a predicate)
-        if (!this.inPredicate &&
+        // The context item expression "." is parsed as self::node() but genuinely
+        // depends on the context item, even inside predicates. Without this,
+        // Predicate.recomputeExecutionMode() may pre-evaluate expressions like
+        // not(.) against the full context sequence instead of item-by-item,
+        // causing FORG0006 errors on atomic sequences (GitHub #2308).
+        if (this.axis == Constants.SELF_AXIS && this.test.getType() == Type.NODE) {
+            // This is "." (context item expression) — always depends on context item
+            deps = deps | Dependency.CONTEXT_ITEM;
+        } else if (!this.inPredicate &&
                 (this.axis == Constants.SELF_AXIS ||
                         (parent != null && parent.getSubExpressionCount() > 0 && parent.getSubExpression(0) == this))) {
             deps = deps | Dependency.CONTEXT_ITEM;

--- a/exist-core/src/main/java/org/exist/xquery/Predicate.java
+++ b/exist-core/src/main/java/org/exist/xquery/Predicate.java
@@ -239,11 +239,17 @@ public class Predicate extends PathExpr {
                     // computation should now be better
                     !((inner instanceof GeneralComparison) &&
                             ((GeneralComparison) inner).invalidNodeEvaluation)) {
-                innerSeq = inner.eval(contextSequence, null);
-                // Only if we have an actual *singleton* of numeric items
-                if (innerSeq.hasOne()
-                        && Type.subTypeOfUnion(innerSeq.getItemType(), Type.NUMERIC)) {
-                    recomputedExecutionMode = POSITIONAL;
+                try {
+                    innerSeq = inner.eval(contextSequence, null);
+                    // Only if we have an actual *singleton* of numeric items
+                    if (innerSeq.hasOne()
+                            && Type.subTypeOfUnion(innerSeq.getItemType(), Type.NUMERIC)) {
+                        recomputedExecutionMode = POSITIONAL;
+                    }
+                } catch (final XPathException e) {
+                    // Pre-evaluation failed (e.g. EBV undefined for multi-item
+                    // atomic sequence as in (true(), false())[not(.)], GitHub #2308).
+                    // Fall back to safe item-by-item BOOLEAN evaluation.
                 }
             }
         } else if (executionMode == NODE && !contextSequence.isPersistentSet()) {
@@ -255,17 +261,23 @@ public class Predicate extends PathExpr {
                  * WARNING : this sequence will be evaluated with
                  * preloadable nodesets !
                  */
-                innerSeq = inner.eval(contextSequence, null);
-                // Try to promote a boolean evaluation to a nodeset one
-                // We are now sure of the inner sequence return type
-                if (Type.subTypeOf(innerSeq.getItemType(), Type.NODE)
-                        && innerSeq.isPersistentSet()) {
-                    recomputedExecutionMode = NODE;
-                    // Try to promote a boolean evaluation to a positional one
-                    // Only if we have an actual *singleton* of numeric items
-                } else if (innerSeq.hasOne()
-                        && Type.subTypeOfUnion(innerSeq.getItemType(), Type.NUMERIC)) {
-                    recomputedExecutionMode = POSITIONAL;
+                try {
+                    innerSeq = inner.eval(contextSequence, null);
+                    // Try to promote a boolean evaluation to a nodeset one
+                    // We are now sure of the inner sequence return type
+                    if (Type.subTypeOf(innerSeq.getItemType(), Type.NODE)
+                            && innerSeq.isPersistentSet()) {
+                        recomputedExecutionMode = NODE;
+                        // Try to promote a boolean evaluation to a positional one
+                        // Only if we have an actual *singleton* of numeric items
+                    } else if (innerSeq.hasOne()
+                            && Type.subTypeOfUnion(innerSeq.getItemType(), Type.NUMERIC)) {
+                        recomputedExecutionMode = POSITIONAL;
+                    }
+                } catch (final XPathException e) {
+                    // Pre-evaluation failed (e.g. type conversion error for
+                    // simple map expressions in predicates, GitHub #3289).
+                    // Fall back to safe item-by-item BOOLEAN evaluation.
                 }
             }
         }

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunNot.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunNot.java
@@ -106,13 +106,16 @@ public class FunNot extends Function {
             (contextSequence == null || contextSequence.isPersistentSet()) &&
             !Dependency.dependsOn(arg, Dependency.CONTEXT_ITEM)) {
 			if (contextSequence == null || contextSequence.isEmpty()) {
-				// TODO: special treatment if the context sequence is empty:
-				// within a predicate, we just return the empty sequence
-				// otherwise evaluate the argument and return a boolean result			    
-//				if (inPredicate && !inWhereClause)
-//                    result = Sequence.EMPTY_SEQUENCE;
-//				else
-                    result = evalBoolean(contextSequence, contextItem, arg);
+				if (inPredicate) {
+					// When used inside a predicate in NODE mode, the result is consumed
+					// as a node set by Predicate.selectByNodeSet(). An empty context
+					// means there are no nodes to filter — the set-difference result
+					// is always empty. Returning a boolean here would crash with
+					// "cannot convert xs:boolean to a node set" (GitHub #2159).
+					result = Sequence.EMPTY_SEQUENCE;
+				} else {
+					result = evalBoolean(contextSequence, contextItem, arg);
+				}
 			} else {
     			result = contextSequence.toNodeSet().copy();
 

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunNot.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunNot.java
@@ -70,11 +70,10 @@ public class FunNot extends Function {
     }
     
 	public int returnsType() {
-		//TODO: test for possible performance lost
-		//return Type.BOOLEAN;
-		return Type.subTypeOf(getArgument(0).returnsType(), Type.NODE)
-			? Type.NODE
-			: Type.BOOLEAN;
+		// fn:not() always returns xs:boolean per the XPath/XQuery specification.
+		// The set-difference optimization for node-set predicates is handled
+		// internally in eval() and preserved via Predicate.recomputeExecutionMode().
+		return Type.BOOLEAN;
 	}
 
 	/* (non-Javadoc)

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunNot.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunNot.java
@@ -70,10 +70,13 @@ public class FunNot extends Function {
     }
     
 	public int returnsType() {
-		// fn:not() always returns xs:boolean per the XPath/XQuery specification.
-		// The set-difference optimization for node-set predicates is handled
-		// internally in eval() and preserved via Predicate.recomputeExecutionMode().
-		return Type.BOOLEAN;
+		// When the argument is a node-returning expression (e.g. a location step),
+		// report NODE so that Predicate.analyze() selects the efficient NODE
+		// execution mode for the set-difference optimization.
+		// Otherwise return BOOLEAN (the spec return type for fn:not).
+		return Type.subTypeOf(getArgument(0).returnsType(), Type.NODE)
+			? Type.NODE
+			: Type.BOOLEAN;
 	}
 
 	/* (non-Javadoc)

--- a/exist-core/src/test/xquery/boolean-sequences.xq
+++ b/exist-core/src/test/xquery/boolean-sequences.xq
@@ -49,10 +49,9 @@ function boolseq:countPositivesContextItem() {
 };
 
 (:~
-  this is the failing issue
+  this was the failing issue — fixed in GitHub #2308
 ~:)
 declare
-    %test:pending
     %test:assertEquals(1)
 function boolseq:countNegativesContextItem() {
     count($boolseq:sequence[not(.)])

--- a/exist-core/src/test/xquery/fn-not-bench.xq
+++ b/exist-core/src/test/xquery/fn-not-bench.xq
@@ -1,0 +1,114 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+(:~
+  Performance and correctness benchmark for fn:not() set-difference optimization.
+  Uses the Shakespeare hamlet.xml sample to verify that not() predicates on
+  persistent node sets still use the efficient set-difference path.
+~:)
+module namespace fn-not-bench="http://exist-db.org/xquery/test/fn-not-bench";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+declare variable $fn-not-bench:collection := 'test-fn-not-bench';
+declare variable $fn-not-bench:doc := 'hamlet.xml';
+
+declare
+    %test:setUp
+function fn-not-bench:setup() {
+    let $hamlet := fn:doc('/db/apps/doc/data/shakespeare/hamlet.xml')
+    return
+        if (exists($hamlet)) then (
+            xmldb:create-collection('/db', $fn-not-bench:collection),
+            xmldb:store('/db/' || $fn-not-bench:collection, $fn-not-bench:doc, $hamlet)
+        ) else (
+            (: Fall back to loading from classpath via a small inline doc :)
+            xmldb:create-collection('/db', $fn-not-bench:collection),
+            xmldb:store('/db/' || $fn-not-bench:collection, $fn-not-bench:doc,
+                <PLAY>
+                    <TITLE>Hamlet</TITLE>
+                    {for $i in 1 to 200 return
+                        <ACT><SCENE><TITLE>Scene {$i}</TITLE>
+                            {for $j in 1 to 20 return
+                                <SPEECH>
+                                    <SPEAKER>{if ($j mod 3 = 0) then "HAMLET" else "OTHER"}</SPEAKER>
+                                    {if ($j mod 5 != 0) then <LINE>Line {$j}</LINE> else ()}
+                                </SPEECH>
+                            }
+                        </SCENE></ACT>
+                    }
+                </PLAY>
+            )
+        )
+};
+
+declare
+    %test:tearDown
+function fn-not-bench:teardown() {
+    xmldb:remove('/db/' || $fn-not-bench:collection)
+};
+
+(:~
+  Correctness: //SPEECH[not(LINE)] must return speeches with no LINE children.
+  This exercises the set-difference optimization on persistent nodes.
+~:)
+declare
+    %test:assertTrue
+function fn-not-bench:not-line-returns-results() {
+    let $dom := doc('/db/' || $fn-not-bench:collection || '/' || $fn-not-bench:doc)
+    return count($dom//SPEECH[not(LINE)]) > 0
+};
+
+(:~
+  Correctness: //SPEECH[not(SPEAKER = 'HAMLET')] filters correctly.
+  This is a general comparison predicate inside not(), not a simple node test,
+  so it goes through the boolean evaluation path.
+~:)
+declare
+    %test:assertTrue
+function fn-not-bench:not-speaker-hamlet() {
+    let $dom := doc('/db/' || $fn-not-bench:collection || '/' || $fn-not-bench:doc)
+    let $all := count($dom//SPEECH)
+    let $hamlet := count($dom//SPEECH[SPEAKER = 'HAMLET'])
+    let $not-hamlet := count($dom//SPEECH[not(SPEAKER = 'HAMLET')])
+    return $not-hamlet = ($all - $hamlet)
+};
+
+(:~
+  Performance: run //SPEECH[not(LINE)] 10 times and verify it completes quickly.
+  This is a smoke test — if the set-difference optimization is broken and falls
+  back to item-by-item boolean evaluation, this would be noticeably slower.
+~:)
+declare
+    %test:assertTrue
+function fn-not-bench:not-line-performance() {
+    let $dom := doc('/db/' || $fn-not-bench:collection || '/' || $fn-not-bench:doc)
+    let $start := util:system-time()
+    let $results :=
+        for $i in 1 to 10
+        return count($dom//SPEECH[not(LINE)])
+    let $end := util:system-time()
+    let $elapsed := ($end - $start) div xs:dayTimeDuration('PT0.001S')
+    (: Should complete 10 iterations in well under 5 seconds :)
+    return $elapsed < 5000
+};

--- a/exist-core/src/test/xquery/fn-not.xq
+++ b/exist-core/src/test/xquery/fn-not.xq
@@ -24,6 +24,7 @@ xquery version "3.1";
 (:~
   Tests for fn:not() predicate handling.
   https://github.com/eXist-db/exist/issues/2159
+  https://github.com/eXist-db/exist/issues/2308
 ~:)
 module namespace fn-not="http://exist-db.org/xquery/test/fn-not";
 
@@ -97,4 +98,32 @@ declare
 function fn-not:persistent-not-self() {
     let $dom := doc('/db/' || $fn-not:collection || '/' || $fn-not:doc)
     return count($dom//item[not(@type = 'a')])
+};
+
+(: #2308 — not(.) on integer sequence :)
+declare
+    %test:assertEquals(1)
+function fn-not:not-dot-integers() {
+    count((0, 1, 2)[not(.)])
+};
+
+(: #2308 — not(.) on string sequence :)
+declare
+    %test:assertEquals(1)
+function fn-not:not-dot-strings() {
+    count(("", "a")[not(.)])
+};
+
+(: #2308 — not(.) on mixed booleans :)
+declare
+    %test:assertEquals(1)
+function fn-not:not-dot-booleans() {
+    count((true(), false())[not(.)])
+};
+
+(: not(.) on in-memory node sequence filters correctly :)
+declare
+    %test:assertEquals(0)
+function fn-not:not-dot-nodes() {
+    count((<a/>, <b/>)[not(.)])
 };

--- a/exist-core/src/test/xquery/fn-not.xq
+++ b/exist-core/src/test/xquery/fn-not.xq
@@ -1,0 +1,100 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+(:~
+  Tests for fn:not() predicate handling.
+  https://github.com/eXist-db/exist/issues/2159
+~:)
+module namespace fn-not="http://exist-db.org/xquery/test/fn-not";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+declare variable $fn-not:collection := 'test-fn-not';
+declare variable $fn-not:doc := 'test.xml';
+declare variable $fn-not:nodes := document {
+    <root>
+        <item type="a"><child/></item>
+        <item type="b"/>
+        <item type="a"/>
+    </root>
+};
+
+declare
+    %test:setUp
+function fn-not:setup() {
+    xmldb:create-collection('/db', $fn-not:collection),
+    xmldb:store('/db/' || $fn-not:collection, $fn-not:doc, $fn-not:nodes)
+};
+
+declare
+    %test:tearDown
+function fn-not:teardown() {
+    xmldb:remove('/db/' || $fn-not:collection)
+};
+
+(: #2159 — not(self::x) on empty derived path must not crash :)
+declare
+    %test:assertEquals(0)
+function fn-not:empty-path-not-self() {
+    let $doc := <root><abc/></root>
+    return count($doc/nonexistent/*[not(self::abc)])
+};
+
+(: #2159 — not(self::x) on non-empty path filters correctly :)
+declare
+    %test:assertEquals(1)
+function fn-not:non-empty-path-not-self() {
+    let $doc := <root><abc/><def/></root>
+    return count($doc/*[not(self::abc)])
+};
+
+(: #2159 — not(*) on empty path returns empty :)
+declare
+    %test:assertEquals(0)
+function fn-not:empty-path-not-wildcard() {
+    let $doc := <root><abc/></root>
+    return count($doc/nonexistent/*[not(*)])
+};
+
+(: Standalone not(()) returns true — boolean path unaffected :)
+declare
+    %test:assertTrue
+function fn-not:standalone-not-empty() {
+    not(())
+};
+
+(: Set-difference optimization on persistent nodes — not(child) :)
+declare
+    %test:assertEquals(2)
+function fn-not:persistent-not-child() {
+    let $dom := doc('/db/' || $fn-not:collection || '/' || $fn-not:doc)
+    return count($dom//item[not(child)])
+};
+
+(: Set-difference optimization on persistent nodes — not(self::x) :)
+declare
+    %test:assertEquals(1)
+function fn-not:persistent-not-self() {
+    let $dom := doc('/db/' || $fn-not:collection || '/' || $fn-not:doc)
+    return count($dom//item[not(@type = 'a')])
+};

--- a/exist-core/src/test/xquery/simple-map-predicate.xq
+++ b/exist-core/src/test/xquery/simple-map-predicate.xq
@@ -1,0 +1,136 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+(:~
+  Tests for simple map operator inside predicates.
+  https://github.com/eXist-db/exist/issues/3289
+
+  The expression @*[name() ! contains(., 'DateTime')] crashes with
+  "Type error: the sequence cannot be converted into a node set.
+  Item type is xs:boolean" when used on persistent (stored) documents.
+~:)
+module namespace smp="http://exist-db.org/xquery/test/simple-map-predicate";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+declare variable $smp:collection := 'test-simple-map-predicate';
+declare variable $smp:doc := 'sts135.xml';
+declare variable $smp:data :=
+    <launch>
+        <event launchDateTime="2011-07-08T11:29:00"
+               landDateTime="2011-07-21T05:57:00"
+               type="mission"/>
+        <event type="test"/>
+    </launch>;
+
+declare
+    %test:setUp
+function smp:setup() {
+    xmldb:create-collection('/db', $smp:collection),
+    xmldb:store('/db/' || $smp:collection, $smp:doc, $smp:data)
+};
+
+declare
+    %test:tearDown
+function smp:teardown() {
+    xmldb:remove('/db/' || $smp:collection)
+};
+
+(:~
+  #3289 — @*[name() ! contains(., 'DateTime')] on stored doc crashes with
+  "Type error: the sequence cannot be converted into a node set."
+~:)
+declare
+    %test:assertEquals(1)
+function smp:persistent-simple-map-contains-in-attr-predicate() {
+    let $doc := doc('/db/' || $smp:collection || '/' || $smp:doc)
+    return count($doc//*[@*[name() ! contains(., 'DateTime')]])
+};
+
+(:~
+  Workaround from #3289: contains(name(.), ...) — should always work.
+~:)
+declare
+    %test:assertEquals(1)
+function smp:persistent-contains-name-dot() {
+    let $doc := doc('/db/' || $smp:collection || '/' || $smp:doc)
+    return count($doc//*[@*[contains(name(.), 'DateTime')]])
+};
+
+(:~
+  Another workaround from #3289: @* ! name()[contains(., ...)]
+~:)
+declare
+    %test:assertEquals(2)
+function smp:persistent-attr-map-name-predicate() {
+    let $doc := doc('/db/' || $smp:collection || '/' || $smp:doc)
+    let $event := $doc//event[1]
+    return count($event/@* ! name()[contains(., 'DateTime')])
+};
+
+(:~
+  Workaround from #3289 comment: @*[name()[contains(., ...)]]
+~:)
+declare
+    %test:assertEquals(1)
+function smp:persistent-nested-name-predicate() {
+    let $doc := doc('/db/' || $smp:collection || '/' || $smp:doc)
+    return count($doc//*[@*[name()[contains(., 'DateTime')]]])
+};
+
+(:~
+  Workaround from #3289 comment: //@*[name() ! contains(., ...)]/..
+~:)
+declare
+    %test:assertEquals(1)
+function smp:persistent-deref-attr-parent() {
+    let $doc := doc('/db/' || $smp:collection || '/' || $smp:doc)
+    return count($doc//@*[name() ! contains(., 'DateTime')]/..)
+};
+
+(:~
+  #3289 comment pattern 1: @* ! name() ! contains(., ...) is expected to fail
+  per spec when multiple attributes produce multiple booleans, since EBV is
+  undefined for a sequence of two or more booleans.
+~:)
+declare
+    %test:assertError("FORG0006")
+function smp:persistent-double-map-expected-error() {
+    let $doc := doc('/db/' || $smp:collection || '/' || $smp:doc)
+    return $doc//*[@* ! name() ! contains(., 'DateTime')]
+};
+
+(:~
+  In-memory version should also work — same pattern, no stored doc.
+~:)
+declare
+    %test:assertEquals(1)
+function smp:inmemory-simple-map-contains-in-attr-predicate() {
+    let $doc :=
+        <launch>
+            <event launchDateTime="2011-07-08T11:29:00"
+                   landDateTime="2011-07-21T05:57:00"
+                   type="mission"/>
+        </launch>
+    return count($doc//*[@*[name() ! contains(., 'DateTime')]])
+};


### PR DESCRIPTION
…redicate pre-evaluation

The LocationStep.getDependencies() change that made self::node() always declare CONTEXT_ITEM dependency was too broad — it affected ALL predicates containing "." (context item), breaking optimized set-based evaluation on persistent node sets and causing widespread test failures across all platforms.

Instead, fix the root cause in Predicate.recomputeExecutionMode() by wrapping the optimization pre-evaluation in try-catch blocks. When pre-evaluation fails (e.g., EBV undefined for multi-item atomic sequences in not(.), or type conversion errors for simple map expressions in predicates), the predicate safely falls back to correct item-by-item BOOLEAN evaluation.

This preserves the efficient set-difference optimization for persistent node set predicates while correctly handling:
- not(.) on atomic sequences (#2308)
- Simple map operators in predicates (#3289)

https://claude.ai/code/session_01SGYvDYjBdi97gCCHkzGAU2