### PR TITLE
[feature] Add instance-wide allow-guest-access clamp

### DIFF
--- a/exist-core/src/main/java/org/exist/http/servlets/AbstractExistHttpServlet.java
+++ b/exist-core/src/main/java/org/exist/http/servlets/AbstractExistHttpServlet.java
@@ -251,10 +251,31 @@ public abstract class AbstractExistHttpServlet extends HttpServlet {
 
         // Secondly try basic authentication if there is no Authorization header or the Authorization header does not indicate Basic auth
         final String auth = request.getHeader("Authorization");
+        final Subject subject;
         if ((auth == null || !auth.toLowerCase().startsWith("basic ")) && getDefaultUser() != null) {
-            return getDefaultUser();
+            subject = getDefaultUser();
+        } else {
+            subject = getAuthenticator().authenticate(request, response, true);
         }
-        return getAuthenticator().authenticate(request, response, true);
+        return rejectGuestIfAccessClamped(subject, request, response);
+    }
+
+    /**
+     * When guest access is clamped instance-wide, refuse to proceed as the guest subject - whether
+     * it arrived via the default user or via explicit guest credentials - and send a challenge so
+     * the caller can authenticate. All HTTP surfaces sharing this servlet base inherit the check.
+     *
+     * @return the supplied subject, or {@code null} if a guest was challenged and must not proceed
+     */
+    private Subject rejectGuestIfAccessClamped(final Subject subject, final HttpServletRequest request,
+            final HttpServletResponse response) throws IOException {
+        final SecurityManager securityManager = getPool().getSecurityManager();
+        if (subject != null && !securityManager.isGuestAccessAllowed()
+                && subject.equals(securityManager.getGuestSubject())) {
+            getAuthenticator().sendChallenge(request, response);
+            return null;
+        }
+        return subject;
     }
 
     protected boolean isInternalOnly() {

--- a/exist-core/src/main/java/org/exist/http/urlrewrite/XQueryURLRewrite.java
+++ b/exist-core/src/main/java/org/exist/http/urlrewrite/XQueryURLRewrite.java
@@ -188,6 +188,12 @@ public class XQueryURLRewrite extends HttpServlet {
             }
         }
 
+        // When guest access is clamped instance-wide, refuse to run the controller as the guest
+        // subject. This servlet does not extend AbstractExistHttpServlet, so it carries its own check.
+        if (guestAccessClamped(user, request, response)) {
+            return;
+        }
+
         try {
             configure();
             //checkCache(user);
@@ -613,6 +619,23 @@ public class XQueryURLRewrite extends HttpServlet {
             }
         }
         authenticator = new BasicAuthenticator(pool);
+    }
+
+    /**
+     * Sends an authentication challenge when guest access is clamped instance-wide and the resolved
+     * user is the guest subject.
+     *
+     * @return {@code true} if a challenge was sent and the request must not proceed
+     */
+    private boolean guestAccessClamped(final Subject user, final HttpServletRequest request,
+            final HttpServletResponse response) throws IOException {
+        final var securityManager = pool.getSecurityManager();
+        if (user != null && !securityManager.isGuestAccessAllowed()
+                && user.equals(securityManager.getGuestSubject())) {
+            authenticator.sendChallenge(request, response);
+            return true;
+        }
+        return false;
     }
 
     private void logResult(final DBBroker broker, final Sequence result) throws SAXException {

--- a/exist-core/src/main/java/org/exist/security/SecurityManager.java
+++ b/exist-core/src/main/java/org/exist/security/SecurityManager.java
@@ -103,6 +103,18 @@ public interface SecurityManager extends Configurable {
    Subject getGuestSubject();
    Group getDBAGroup();
 
+   /**
+    * Determines whether anonymous (guest) access is permitted for this instance.
+    *
+    * When this returns {@code false}, guest-reachable entry points should refuse to
+    * proceed as the {@link #GUEST_USER} subject and instead require authentication.
+    * Defaults to {@code true} (guest access permitted), which preserves the historical
+    * behavior; setting it to {@code false} is a deliberate instance-wide lockdown.
+    *
+    * @return {@code true} if guest access is allowed, {@code false} if it is clamped
+    */
+   boolean isGuestAccessAllowed();
+
    List<Account> getGroupMembers(String groupName);
 
    @Deprecated //use realm's method

--- a/exist-core/src/main/java/org/exist/security/internal/SecurityManagerImpl.java
+++ b/exist-core/src/main/java/org/exist/security/internal/SecurityManagerImpl.java
@@ -113,6 +113,9 @@ public class SecurityManagerImpl implements SecurityManager, BrokerPoolService {
     @SuppressWarnings("unused")
     private String version = "2.1";
 
+    @ConfigurationFieldAsAttribute("allow-guest-access")
+    private boolean allowGuestAccess = true;
+
     @ConfigurationFieldAsElement("authentication-entry-point")
     private static final String authenticationEntryPoint = "/authentication/login";
 
@@ -890,6 +893,11 @@ public class SecurityManagerImpl implements SecurityManager, BrokerPoolService {
     @Override
     public String getAuthenticationEntryPoint() {
         return authenticationEntryPoint;
+    }
+
+    @Override
+    public boolean isGuestAccessAllowed() {
+        return allowGuestAccess;
     }
 
     @ThreadSafe

--- a/exist-core/src/main/java/org/exist/xmlrpc/XmldbRequestProcessorFactory.java
+++ b/exist-core/src/main/java/org/exist/xmlrpc/XmldbRequestProcessorFactory.java
@@ -93,7 +93,8 @@ public class XmldbRequestProcessorFactory implements RequestProcessorFactoryFact
             password = username;
         }
 
-        if (!useDefaultUser && username.equalsIgnoreCase(SecurityManager.GUEST_USER)) {
+        if (username.equalsIgnoreCase(SecurityManager.GUEST_USER)
+                && (!useDefaultUser || !brokerPool.getSecurityManager().isGuestAccessAllowed())) {
             final String message = "The user " + SecurityManager.GUEST_USER + " is prohibited from logging in through XML-RPC.";
             LOG.debug(message);
             throw new XmlRpcException(0, message);

--- a/exist-core/src/test/java/org/exist/security/GuestAccessTest.java
+++ b/exist-core/src/test/java/org/exist/security/GuestAccessTest.java
@@ -1,0 +1,172 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.security;
+
+import org.apache.commons.codec.binary.Base64;
+import org.apache.xmlrpc.XmlRpcException;
+import org.apache.xmlrpc.client.XmlRpcClient;
+import org.apache.xmlrpc.client.XmlRpcClientConfigImpl;
+import org.eclipse.jetty.http.HttpStatus;
+import org.exist.security.internal.SecurityManagerImpl;
+import org.exist.storage.BrokerPool;
+import org.exist.storage.DBBroker;
+import org.exist.test.ExistWebServer;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+import java.util.Optional;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+
+/**
+ * Verifies the instance-wide guest access clamp ({@code allow-guest-access}).
+ *
+ * <p>When guest access is clamped, every externally-reachable entry point must refuse to proceed
+ * as the {@code guest} subject (sending a 401 challenge so the caller can authenticate), while
+ * authenticated requests and the database's own internal guest-leased work keep functioning.</p>
+ *
+ * <p>The clamp is driven by a {@code config.xml} attribute bound through the generic
+ * {@link org.exist.config.Configurator} (the same path as the existing {@code version} attribute,
+ * exercised by {@code org.exist.config.ConfigurableTest}); a runtime edit takes effect via
+ * {@code ConfigurationImpl#checkForUpdates} re-running {@code Configurator.configure} on the live
+ * instance. This test toggles the resolved predicate directly so it can assert the enforcement
+ * behavior at each surface without restarting the server, mirroring that no-restart property.</p>
+ */
+public class GuestAccessTest {
+
+    @ClassRule
+    public static final ExistWebServer existWebServer = new ExistWebServer(true, false, true, true);
+
+    private static final String ADMIN_CREDENTIALS = Base64.encodeBase64String("admin:".getBytes(UTF_8));
+
+    private static String guestQueryUri() {
+        return "http://localhost:" + existWebServer.getPort() + "/rest/db?_query=1";
+    }
+
+    @Test
+    public void restGuestBlockedWhenClampedAndRestoredAfterwards() throws Exception {
+        final BrokerPool pool = BrokerPool.getInstance();
+
+        // Baseline: guest access allowed (the default) -> a guest query succeeds.
+        assertEquals(HttpStatus.OK_200, responseCode(getConnection(guestQueryUri(), null)));
+
+        setGuestAccessAllowed(pool, false);
+        try {
+            // Clamped: an unauthenticated (guest) request is challenged.
+            assertEquals(HttpStatus.UNAUTHORIZED_401, responseCode(getConnection(guestQueryUri(), null)));
+            // Clamped: an authenticated request is unaffected.
+            assertEquals(HttpStatus.OK_200, responseCode(getConnection(guestQueryUri(), ADMIN_CREDENTIALS)));
+        } finally {
+            setGuestAccessAllowed(pool, true);
+        }
+
+        // Restored at runtime without a restart -> a guest query succeeds again.
+        assertEquals(HttpStatus.OK_200, responseCode(getConnection(guestQueryUri(), null)));
+    }
+
+    @Test
+    public void xmlRpcGuestBlockedWhenClampedAndRestoredAfterwards() throws Exception {
+        final BrokerPool pool = BrokerPool.getInstance();
+
+        // Baseline: a guest XML-RPC call succeeds.
+        assertNotNull(guestXmlRpcClient().execute("getVersion", List.of()));
+
+        setGuestAccessAllowed(pool, false);
+        try {
+            // Clamped: the guest is rejected at authentication, before any method dispatch.
+            final XmlRpcClient guest = guestXmlRpcClient();
+            assertThrows(XmlRpcException.class, () -> guest.execute("getVersion", List.of()));
+        } finally {
+            setGuestAccessAllowed(pool, true);
+        }
+
+        // Restored at runtime without a restart -> a guest call succeeds again.
+        assertNotNull(guestXmlRpcClient().execute("getVersion", List.of()));
+    }
+
+    /**
+     * Enforcement must live at the per-protocol authentication entry points, NOT at the broker
+     * lease: internal subsystems (scheduler, sanity report, autodeploy, triggers) legitimately
+     * lease a guest broker and must keep working while the clamp is on.
+     */
+    @Test
+    public void internalGuestBrokerLeaseStillWorksWhenClamped() throws Exception {
+        final BrokerPool pool = BrokerPool.getInstance();
+
+        setGuestAccessAllowed(pool, false);
+        try (final DBBroker broker = pool.get(Optional.empty())) {
+            assertEquals(pool.getSecurityManager().getGuestSubject(), broker.getCurrentSubject());
+        } finally {
+            setGuestAccessAllowed(pool, true);
+        }
+    }
+
+    private static int responseCode(final HttpURLConnection connection) throws IOException {
+        try {
+            connection.setRequestMethod("GET");
+            connection.connect();
+            return connection.getResponseCode();
+        } finally {
+            connection.disconnect();
+        }
+    }
+
+    private static HttpURLConnection getConnection(final String url, final String credentials) throws IOException {
+        final HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+        if (credentials != null) {
+            connection.setRequestProperty("Authorization", "Basic " + credentials);
+        }
+        return connection;
+    }
+
+    private static XmlRpcClient guestXmlRpcClient() throws MalformedURLException {
+        final XmlRpcClient client = new XmlRpcClient();
+        final XmlRpcClientConfigImpl config = new XmlRpcClientConfigImpl();
+        config.setEnabledForExtensions(true);
+        config.setServerURL(new URL("http://localhost:" + existWebServer.getPort() + "/xmlrpc"));
+        // No basic credentials: the server resolves the request to the guest subject.
+        client.setConfig(config);
+        return client;
+    }
+
+    /**
+     * Toggles the resolved guest-access predicate on the live security manager. The
+     * {@code config.xml} attribute binding and its runtime reload are generic
+     * {@link org.exist.config.Configurator} machinery; this reaches the same field the reload path
+     * sets, so the enforcement assertions exercise exactly the runtime state a config edit produces.
+     */
+    private static void setGuestAccessAllowed(final BrokerPool pool, final boolean allowed) throws ReflectiveOperationException {
+        final SecurityManagerImpl securityManager = (SecurityManagerImpl) pool.getSecurityManager();
+        final Field field = SecurityManagerImpl.class.getDeclaredField("allowGuestAccess");
+        field.setAccessible(true);
+        field.setBoolean(securityManager, allowed);
+    }
+}

--- a/extensions/webdav/src/main/java/org/exist/webdav/ExistWebdavServlet.java
+++ b/extensions/webdav/src/main/java/org/exist/webdav/ExistWebdavServlet.java
@@ -594,8 +594,10 @@ public class ExistWebdavServlet extends AbstractWebdavServlet {
             if (subject == null) {
                 subject = securityManager.getGuestSubject();
             }
+            // Guest is always refused write methods; when guest access is clamped instance-wide
+            // it is refused all methods (reads included).
             if (subject.equals(securityManager.getGuestSubject())
-                    && WRITE_METHODS.contains(request.getMethod())) {
+                    && (!securityManager.isGuestAccessAllowed() || WRITE_METHODS.contains(request.getMethod()))) {
                 throw new DavException(DavServletResponse.SC_UNAUTHORIZED, "Authentication required");
             }
             request.setDavSession(new ExistDavSession(subject));


### PR DESCRIPTION

[This PR was co-authored with Claude Code. -Joe]

## Summary

Adds an instance-wide guest-access clamp: a single `allow-guest-access` setting on the `<security-manager>` element of the in-database security config (`/db/system/security/config.xml`). It defaults to `true` (guest access permitted — today's behavior is unchanged). When set to `false`, every externally-reachable entry point refuses to proceed as the `guest` subject and instead requires authentication, while the database's own internal guest-leased work keeps running.

This generalizes guest lockdown into core, rather than each API inventing its own guard. The setting is runtime-toggleable (editing the security config takes effect without a restart, via the existing `ConfigurationDocumentTrigger` reload), which doubles as an incident-response / maintenance-mode lever.

## What changed

**New predicate + config**
- `SecurityManager.isGuestAccessAllowed()` (interface) — new predicate.
- `SecurityManagerImpl` — `@ConfigurationFieldAsAttribute("allow-guest-access")` boolean field, default `true`, bound through the existing `Configurator` machinery (same path as the existing `version` attribute) and re-applied on runtime config reload.

**Enforcement hooks (per-protocol authentication entry points)**
- `AbstractExistHttpServlet.authenticate()` — shared by REST (`EXistServlet`), RESTXQ (`RestXqServlet`), `XQueryServlet`, `RedirectorServlet`. When the resolved subject is guest and the clamp is on, sends a `401` Basic-auth challenge instead of proceeding (extracted to a helper so the method's NPath stays under threshold).
- `XQueryURLRewrite.service()` — the controller/URL-rewrite entry point for `/exist/apps/...`. **This servlet does not extend `AbstractExistHttpServlet`**, so it carries its own copy of the check. (Without this, the controller path — including the existdb-openapi app and eXide — would remain a guest bypass.)
- `XmldbRequestProcessorFactory.authenticate()` (XML-RPC, e.g. `xst run`) — extends the existing guest-prohibition block to also fire when the clamp is on.
- `ExistWebdavServlet.ExistDavSessionProvider.attachSession()` (WebDAV) — the existing guest-write block is extended to refuse guest for all methods (reads included) when the clamp is on.

**Deliberately NOT changed**
- `BrokerPool.get(...)`'s guest fallback is left untouched. It is not request-scoped and is used by legitimate internal work (scheduler, sanity report, autodeploy, triggers); enforcing there would break the server's own background tasks. Enforcement belongs at the per-protocol authentication entry, not the broker lease.

## Reject semantics
- HTTP / WebDAV: `401` + `WWW-Authenticate` challenge (invites credentials; not `403`).
- XML-RPC: `XmlRpcException` (mirrors the existing guest-prohibition fault).

## Test plan
New `GuestAccessTest` (embedded Jetty + broker pool):
- REST: guest query returns `200` by default; `401` when clamped; an authenticated (admin) request is unaffected; and `200` again after the clamp is lifted at runtime (no restart).
- XML-RPC: a guest call succeeds by default; throws when clamped; succeeds again after the clamp is lifted.
- Internal: with the clamp on, an internal guest broker lease (`BrokerPool.get(Optional.empty())`) still succeeds and runs as the guest subject — proving the broker fallback is untouched.

Regression: full `RESTServiceTest` (47) and `XmlRpcTest` (46) pass unchanged with the default (guest allowed).

## Notes for review
- **NPath:** `XQueryURLRewrite.service()` is a pre-existing very-high-NPath method (already far over threshold on develop). The guest-clamp guard adds one unavoidable early-return branch; it is extracted into a helper (`guestAccessClamped`) to minimize the footprint. The HTTP servlet check is likewise extracted (`rejectGuestIfAccessClamped`) and keeps `authenticate()` under threshold.
- **Carve-out / allow-list (follow-up):** for Basic-auth surfaces, rejecting guest sends a `401` challenge, which *is* the login affordance — so a clamped instance stays loginnable with no allow-list. A configurable allow-list (so an app can serve its own anonymous login UI, e.g. eXide via a route handler) is the planned next step and is intentionally out of scope here.
